### PR TITLE
[feature] MySQL 도커 환경 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,3 +50,49 @@ tasks.register('copyConfig', Copy) {
 }
 
 processResources.dependsOn('copyConfig')
+
+// Docker Compose 관리 태스크
+tasks.register('dockerUp', Exec) {
+    group = 'docker'
+    description = 'Start Docker Compose services'
+    commandLine 'docker-compose', 'up', '-d'
+}
+
+tasks.register('dockerDown', Exec) {
+    group = 'docker'
+    description = 'Stop Docker Compose services'
+    commandLine 'docker-compose', 'down'
+}
+
+tasks.register('dockerRestart', Exec) {
+    group = 'docker'
+    description = 'Restart Docker Compose services'
+    commandLine 'docker-compose', 'restart'
+}
+
+tasks.register('dockerLogs', Exec) {
+    group = 'docker'
+    description = 'Show Docker Compose logs'
+    commandLine 'docker-compose', 'logs', '-f'
+}
+
+tasks.named('bootRun') {
+    dependsOn 'dockerUp'
+    doFirst {
+        println "Starting Docker Compose services..."
+    }
+}
+
+tasks.named('test') {
+    dependsOn 'dockerUp'
+    doFirst {
+        println "Starting Docker Compose services for testing..."
+    }
+}
+
+tasks.named('build') {
+    dependsOn 'dockerUp'
+    doFirst {
+        println "Ensuring Docker Compose services are running..."
+    }
+}

--- a/src/main/java/com/sparta/foodorder/domain/address/domain/Address.java
+++ b/src/main/java/com/sparta/foodorder/domain/address/domain/Address.java
@@ -1,0 +1,73 @@
+package com.sparta.foodorder.domain.address.domain;
+
+import com.sparta.foodorder.domain.user.domain.User;
+import com.sparta.foodorder.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "addresses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 200)
+    private String address;
+
+    @Column(length = 100)
+    private String detailAddress;
+
+    @Column(length = 10)
+    private String zipCode;
+
+    @Column(length = 50)
+    private String recipientName;
+
+    @Column(length = 20)
+    private String recipientPhone;
+
+    @Column(nullable = false)
+    private Boolean isDefault = false;
+
+    @Builder
+    public Address(User user, String address, String detailAddress, String zipCode, 
+                   String recipientName, String recipientPhone, Boolean isDefault) {
+        this.user = user;
+        this.address = address;
+        this.detailAddress = detailAddress;
+        this.zipCode = zipCode;
+        this.recipientName = recipientName;
+        this.recipientPhone = recipientPhone;
+        this.isDefault = isDefault != null ? isDefault : false;
+    }
+
+    public void updateAddress(String address, String detailAddress, String zipCode) {
+        this.address = address;
+        this.detailAddress = detailAddress;
+        this.zipCode = zipCode;
+    }
+
+    public void updateRecipient(String recipientName, String recipientPhone) {
+        this.recipientName = recipientName;
+        this.recipientPhone = recipientPhone;
+    }
+
+    public void setAsDefault() {
+        this.isDefault = true;
+    }
+
+    public void setAsNotDefault() {
+        this.isDefault = false;
+    }
+}

--- a/src/main/java/com/sparta/foodorder/domain/address/infrastructure/AddressRepository.java
+++ b/src/main/java/com/sparta/foodorder/domain/address/infrastructure/AddressRepository.java
@@ -1,0 +1,21 @@
+package com.sparta.foodorder.domain.address.infrastructure;
+
+import com.sparta.foodorder.domain.address.domain.Address;
+import com.sparta.foodorder.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AddressRepository extends JpaRepository<Address, Long> {
+    
+    List<Address> findByUserOrderByCreatedAtDesc(User user);
+    
+    Optional<Address> findByUserAndIsDefaultTrue(User user);
+    
+    List<Address> findByUserId(Long userId);
+    
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/sparta/foodorder/domain/user/domain/User.java
+++ b/src/main/java/com/sparta/foodorder/domain/user/domain/User.java
@@ -1,0 +1,65 @@
+package com.sparta.foodorder.domain.user.domain;
+
+import com.sparta.foodorder.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(length = 20)
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role = UserRole.CUSTOMER;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    @Builder
+    public User(String username, String password, String email, String phoneNumber, UserRole role) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.role = role != null ? role : UserRole.CUSTOMER;
+    }
+
+    public void updateProfile(String email, String phoneNumber) {
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public void deactivate() {
+        this.status = UserStatus.INACTIVE;
+    }
+
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/sparta/foodorder/domain/user/domain/UserRole.java
+++ b/src/main/java/com/sparta/foodorder/domain/user/domain/UserRole.java
@@ -1,0 +1,14 @@
+package com.sparta.foodorder.domain.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+    CUSTOMER("고객"),
+    STORE_OWNER("사장"),
+    ADMIN("관리자");
+
+    private final String description;
+}

--- a/src/main/java/com/sparta/foodorder/domain/user/domain/UserStatus.java
+++ b/src/main/java/com/sparta/foodorder/domain/user/domain/UserStatus.java
@@ -1,0 +1,14 @@
+package com.sparta.foodorder.domain.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserStatus {
+    ACTIVE("활성"),
+    INACTIVE("비활성"),
+    SUSPENDED("정지");
+
+    private final String description;
+}

--- a/src/main/java/com/sparta/foodorder/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/sparta/foodorder/domain/user/infrastructure/UserRepository.java
@@ -1,0 +1,19 @@
+package com.sparta.foodorder.domain.user.infrastructure;
+
+import com.sparta.foodorder.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    Optional<User> findByUsername(String username);
+    
+    Optional<User> findByEmail(String email);
+    
+    boolean existsByUsername(String username);
+    
+    boolean existsByEmail(String email);
+}


### PR DESCRIPTION
이슈번호 : #2

## 📄 Work Description

#### 1. User와 Address 도메인을 DDD 패턴으로 재구성
- 기존 `entity/`, `repository/` 폴더를 `domain/`, `infrastructure/` 폴더로 이동
- payment 도메인과 동일한 DDD 아키텍처 구조로 통일
- 모든 도메인이 일관된 패턴을 따르도록 구조 변경



#### 2. Docker Compose 설정 및 Gradle 통합
- MySQL 8.0 컨테이너 설정 추가
- Gradle 빌드 시 Docker 자동 실행 기능 구현
- 애플리케이션 실행/테스트 시 Docker 서비스 자동 시작