### PR TITLE
[feature] 예외처리 추가

### DIFF
--- a/src/main/java/com/sparta/foodorder/global/exception/BusinessException.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.sparta.foodorder.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/foodorder/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.sparta.foodorder.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 공통 에러
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C002", "잘못된 타입입니다"),
+    MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C003", "필수 입력값이 누락되었습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 오류가 발생했습니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "허용되지 않은 HTTP 메서드입니다"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "접근이 거부되었습니다"),
+
+    // 사용자 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U002", "이미 존재하는 이메일입니다"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 일치하지 않습니다"),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "U004", "인증되지 않은 사용자입니다"),
+
+    // 상품 관련 에러
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "상품을 찾을 수 없습니다"),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "P002", "재고가 부족합니다"),
+
+    // 주문 관련 에러
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "주문을 찾을 수 없습니다"),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "O002", "잘못된 주문 상태입니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/foodorder/global/exception/ErrorResponse.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/ErrorResponse.java
@@ -1,0 +1,65 @@
+package com.sparta.foodorder.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final int status;
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+    private final List<FieldError> fieldErrors;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String customMessage) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(customMessage)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .fieldErrors(errors)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            return bindingResult.getFieldErrors()
+                    .stream()
+                    .map(error -> FieldError.builder()
+                            .field(error.getField())
+                            .value(error.getRejectedValue() == null ? "" : error.getRejectedValue().toString())
+                            .reason(error.getDefaultMessage())
+                            .build())
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/sparta/foodorder/global/exception/ErrorResponse.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.sparta.foodorder.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
     private final int status;
     private final String code;
@@ -46,6 +48,7 @@ public class ErrorResponse {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class FieldError {
         private final String field;
         private final String value;

--- a/src/main/java/com/sparta/foodorder/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.sparta.foodorder.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
+        log.error("BusinessException: code={}, message={}", ex.getErrorCode().getCode(), ex.getMessage());
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(errorCode, ex.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    // Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex) {
+        log.error("MethodArgumentNotValidException: {}", ex.getMessage());
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.INVALID_INPUT_VALUE,
+                ErrorResponse.FieldError.of(ex.getBindingResult()));
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    // 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("Unhandled Exception: ", ex);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/sparta/foodorder/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/foodorder/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
-
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

issue : #9

## 📄 Work Description
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 전역 예외 처리 기본 구조를 구현했습니다.
(작업한 부분 설명 및 코드와 이미지 첨부)
- `ErrorCode` 인터페이스 및 공통 에러 코드 Enum 생성
   - HTTP 상태코드, 도메인별 에러 코드, 메시지로 구성
   - INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
- `BusinessException` 커스텀 예외 클래스 구현
   - 비즈니스 로직에서 발생하는 예외를 처리하기 위한 기본 예외 클래스
   - ErrorCode를 포함하여 일관된 에러 응답 생성
   - 커스텀 메시지 작성 가능 
- `ErrorResponse` DTO를 통한 일관된 에러 응답 형식 정의
- `GlobalExceptionHandler`로 전역 예외 처리
   - `BusinessException`: 비즈니스 로직 예외
   - `MethodArgumentNotValidException`: Validation 예외
   - `Exception`: 예상하지 못한 모든 예외

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->
- `ErrorCode`의 형식에 도메인별 에러 코드를 넣도록 했는데 (`C001`, `U001`, `P001` 등) 적절한지 검토해주세요.
- `GlobalExceptionHandler`는 현재 3개정도만 구현했는데 더 필요한 예외 핸들러가 있다면 추가하겠습니다.
<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
