### PR TITLE
[feature] swagger 기본 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/foodorder/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/foodorder/global/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.sparta.foodorder.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("foodorder API")
+                        .version("v1.0")
+                        .description("foodorder API 문서"));
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

issue : #4 

## 📄 Work Description
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. swagger 기본설정
- build.gradle 파일에 의존성 추가
- global > config 에 SwaggerConfig 설정 클래스 추가
<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->
- swagger를 사용해본 적이 없어서 추가 설정이 뭐가 필요한지 몰라 기본설정만 넣었습니다. 
- url path가 포함된 yml파일도 바로 추가할 예정입니다. 
- issue 발생이 처음이고 깃허브 협업 경험이 많지 않아서 혹시 미흡한 점이 있다면 코멘트 부탁드려요

<br/>


