### PR TITLE
[fix] AI 응답 DB 저장 시 유저 ID 반영

### DIFF
--- a/src/main/java/com/sparta/foodorder/domain/ai/application/AiService.java
+++ b/src/main/java/com/sparta/foodorder/domain/ai/application/AiService.java
@@ -34,14 +34,11 @@ public class AiService {
         this.aiLogRepository = aiLogRepository;
     }
 
-    public AiResponseDto generateContent(String productName, String content) {
-        return generateContent(productName, content, defaultProvider);
-    }
-
-    public AiResponseDto generateContent(String productName, String content, String providerName) {
+    public AiResponseDto generateContent(Long userId, String productName, String content, String providerName) {
         String prompt = promptBuilder.buildProductGeneratePrompt(productName, content);
 
         AiRequestDto request = AiRequestDto.builder()
+                .userId(userId)
                 .productName(productName)
                 .content(content)
                 .prompt(prompt)
@@ -60,9 +57,8 @@ public class AiService {
         log.info("AI 컨텐츠 생성 요청 - Provider: {}", providerName);
         AiResponseDto aiResponseDto = provider.generateContent(request);
 
-        // TODO. 유저 ID 받아서 적용 필요
         AiLog aiLog = AiLog.builder()
-                .userId(1L)  // TODO. 수정필요
+                .userId(request.getUserId())
                 .aiModel(aiResponseDto.getModel())
                 .productName(request.getProductName())
                 .requestContent(request.getContent())

--- a/src/main/java/com/sparta/foodorder/domain/ai/application/dto/AiRequestDto.java
+++ b/src/main/java/com/sparta/foodorder/domain/ai/application/dto/AiRequestDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiRequestDto {
+    private Long userId;
     private String productName;
     private String content;
     private String prompt;

--- a/src/main/java/com/sparta/foodorder/domain/ai/presentation/AiGenerationController.java
+++ b/src/main/java/com/sparta/foodorder/domain/ai/presentation/AiGenerationController.java
@@ -2,9 +2,13 @@ package com.sparta.foodorder.domain.ai.presentation;
 
 import com.sparta.foodorder.domain.ai.application.AiService;
 import com.sparta.foodorder.domain.ai.application.dto.AiResponseDto;
+import com.sparta.foodorder.domain.auth.infrastructure.CustomUserDetails;
+import com.sparta.foodorder.global.exception.BusinessException;
+import com.sparta.foodorder.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,7 +27,12 @@ public class AiGenerationController {
     public AiResponseDto aiGenerate(
             @RequestParam String productName,
             @RequestParam(required = false) String content,
-            @RequestParam(required = false, defaultValue = "gemini") String provider) {
-        return aiService.generateContent(productName, content, provider);
+            @RequestParam(required = false, defaultValue = "gemini") String provider,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        if (userDetails == null)
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+
+        return aiService.generateContent(userDetails.getUserId(), productName, content, provider);
     }
 }

--- a/src/test/java/com/sparta/foodorder/ai/AiServiceTest.java
+++ b/src/test/java/com/sparta/foodorder/ai/AiServiceTest.java
@@ -1,0 +1,108 @@
+package com.sparta.foodorder.ai;
+
+import com.sparta.foodorder.domain.ai.application.AiService;
+import com.sparta.foodorder.domain.ai.application.PromptBuilder;
+import com.sparta.foodorder.domain.ai.application.dto.AiRequestDto;
+import com.sparta.foodorder.domain.ai.application.dto.AiResponseDto;
+import com.sparta.foodorder.domain.ai.domain.AiLog;
+import com.sparta.foodorder.domain.ai.domain.AiProvider;
+import com.sparta.foodorder.domain.ai.infrastructure.AiLogRepository;
+import com.sparta.foodorder.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AiService 테스트")
+public class AiServiceTest {
+
+    @Mock
+    private AiProvider geminiProvider;
+
+    @Mock
+    private PromptBuilder promptBuilder;
+
+    @Mock
+    private AiLogRepository aiLogRepository;
+
+    private AiService aiService;
+
+    @BeforeEach
+    void setUp() {
+        when(geminiProvider.getProviderName()).thenReturn("gemini");
+
+        aiService = new AiService(
+                List.of(geminiProvider),
+                promptBuilder,
+                aiLogRepository
+        );
+
+        ReflectionTestUtils.setField(aiService, "defaultProvider", "gemini");
+    }
+
+    @Test
+    @DisplayName("AI 컨텐츠 생성 성공 - Gemini")
+    void generateContent_Success_WithGemini() {
+        // given
+        Long userId = 1L;
+        String productName = "김치찌개";
+        String content = "김치를 기반으로 하는 찌개 요리";
+        String prompt = "매콤하고 얼큰한 김치찌개입니다.";
+
+        AiResponseDto expectedResponse = AiResponseDto.builder()
+                .generatedText(prompt)
+                .provider("gemini")
+                .model("gemini-2.5-flash")
+                .build();
+
+        when(promptBuilder.buildProductGeneratePrompt(productName, content))
+                .thenReturn(prompt);
+
+        when(geminiProvider.generateContent(any(AiRequestDto.class)))
+                .thenReturn(expectedResponse);
+
+        when(aiLogRepository.save(any(AiLog.class)))
+                .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        // when
+        AiResponseDto result = aiService.generateContent(userId, productName, content, "gemini");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getGeneratedText()).isEqualTo("매콤하고 얼큰한 김치찌개입니다.");
+        verify(promptBuilder, times(1)).buildProductGeneratePrompt(productName, content);
+        verify(geminiProvider, times(1)).generateContent(any(AiRequestDto.class));
+        verify(aiLogRepository, times(1)).save(any(AiLog.class));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 AI Provider 예외 발생")
+    void generateContent_Exception_ProviderNotFound() {
+        // given
+        Long userId = 1L;
+        String productName = "김치찌개";
+        String content = "김치를 기반으로 하는 찌개 요리";
+        String invalidProvider = "invalid-provider";
+
+        when(promptBuilder.buildProductGeneratePrompt(productName, content))
+                .thenReturn("test prompt");
+
+        // when & then
+        assertThrows(BusinessException.class, () -> {
+            aiService.generateContent(userId, productName, content, invalidProvider);
+        });
+
+        verify(aiLogRepository, never()).save(any(AiLog.class));
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 이슈 이름과 동일하게 작성해주세요.
  (예시 : [feature] 로그 설정)

merge commit message는 "PR 제목 + (#PR번호)"로 작성해주세요. 
  (예시 : [feature] 로그 설정 (#9))
-->

close #56

## 📄 Work Description
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. AI 응답 DB 저장 시 유저 ID 반영
#### 2. AiService 테스트 코드 추가
<img width="339" height="78" alt="image" src="https://github.com/user-attachments/assets/8d94ba3d-928f-4b4d-a113-3aecfb15df00" />

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
